### PR TITLE
Introduce state manager

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -216,6 +216,9 @@ class Game(arcade.Window):
         self.light_pbar.value = self._player_light_ratio()
         self.light_pbar.update_bar()
 
+        if self.state.is_paused():
+            return
+
         # Обновляем сцену, чтобы вызвать Sprite.update на всех спрайтах (анимация движения)
         if self.scene:
             self.scene.update(delta_time)
@@ -296,8 +299,14 @@ class Game(arcade.Window):
             if self.camera_controller is not None:
                 self.camera_controller.zoom_out()
             return
+        if symbol == arcade.key.ESCAPE:
+            self.state.toggle_pause()
+            return
 
         now = time.time()
+        if self.state.is_paused():
+            return
+
         if symbol in PLAYER_DIRECTION_KEYS:
             self.movement_input.press(symbol, now)
             self._process_player_movement(now)
@@ -378,6 +387,8 @@ class Game(arcade.Window):
 
     def process_enemy_turns(self):
         """Запускает последовательную обработку ходов всех врагов с ожиданием их анимаций."""
+        if self.state.is_paused():
+            return
         # Сформируем очередь живых врагов
         enemies = list(self.scene.get_sprite_list("Skeleton") or [])
         self._enemy_queue = deque(e for e in enemies if not getattr(e, 'removed', False))
@@ -390,6 +401,9 @@ class Game(arcade.Window):
         Обрабатывает следующий враг из очереди. Если враг начинает анимацию — ждём её завершения.
         Иначе продолжаем к следующему врагу. По окончании возвращаем ход игроку.
         """
+        if self.state.is_paused():
+            return
+
         while self._enemy_queue:
             enemy = self._enemy_queue.popleft()
             # Пропуск мёртвых/удалённых сущностей

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,14 @@ from pathlib import Path
 import arcade
 from arcade import gl
 from arcade.future.light import Light, LightLayer
-from sv.core import CameraController, MovementInputState, Settings, snap_world_point
+from sv.core import (
+    CameraController,
+    GamePhase,
+    MovementInputState,
+    Settings,
+    StateManager,
+    snap_world_point,
+)
 from sv.world import LevelGenerator
 from sv.entities import Player, Skeleton
 from sv.ai import decide_enemy_action
@@ -58,8 +65,7 @@ class Game(arcade.Window):
         self.light_layer = None
         self.player_light = None
         self.light_pbar = None
-        # Состояние хода: "player" или другие состояния
-        self.turn = "player"
+        self.state = StateManager()
         # Очередь врагов для последовательной обработки
         self._enemy_queue: deque = deque()
         self._current_enemy = None
@@ -184,6 +190,7 @@ class Game(arcade.Window):
 
         # Добавляем подложку в UI
         self.ui.add(self.hud_anchor)
+        self.state.enter_game()
 
     def on_resize(self, width, height):
         super().on_resize(width, height)
@@ -227,10 +234,9 @@ class Game(arcade.Window):
         now = time.time()
 
         # Если игрок завершил свою анимацию — запускаем очередь врагов
-        if self.turn == "waiting_player_anim":
+        if self.state.is_player_anim():
             if not getattr(self.player_sprite, "moving", False):
-                # Переключаемся в обработку врагов
-                self.turn = "enemy"
+                self.state.set_phase(GamePhase.ENEMY_TURN)
                 self.process_enemy_turns()
                 return
 
@@ -298,13 +304,13 @@ class Game(arcade.Window):
             return
 
         # Игрок может действовать только в свой ход
-        if self.turn != "player":
+        if not self.state.is_player_turn():
             return
 
         # Пропуск хода по пробелу
         if symbol == arcade.key.SPACE:
             self._recover_player_light(2)
-            self.turn = "enemy"
+            self.state.set_phase(GamePhase.ENEMY_TURN)
             self.process_enemy_turns()
             return
 
@@ -332,13 +338,12 @@ class Game(arcade.Window):
             if blocker is not None and hasattr(self.player_sprite, 'attack'):
                 self.player_sprite.attack(blocker)
                 self._consume_player_light(1)
-            # Завершаем ход игрока
-            self.turn = "enemy"
+            self.state.set_phase(GamePhase.ENEMY_TURN)
             self.process_enemy_turns()
             return res, blocker
         if res == MoveResult.MOVED:
             self._consume_player_light(1)
-            self.turn = "waiting_player_anim"
+            self.state.set_phase(GamePhase.PLAYER_ANIM)
             return res, blocker
         return res, blocker
 
@@ -346,7 +351,7 @@ class Game(arcade.Window):
         self.movement_input.release(symbol, time.time())
 
     def _process_player_movement(self, now: float):
-        if self.turn != "player":
+        if not self.state.is_player_turn():
             return
 
         move = self.movement_input.resolve_move(now)
@@ -426,7 +431,7 @@ class Game(arcade.Window):
             continue
 
         # Очередь пуста — возвращаем ход игроку
-        self.turn = "player"
+        self.state.set_phase(GamePhase.PLAYER_TURN)
 
 
 def main():

--- a/src/sv/core/__init__.py
+++ b/src/sv/core/__init__.py
@@ -1,5 +1,5 @@
-"""Core systems (config, game state)."""
+"""Core systems (config, camera, input, state)."""
 from .camera_controller import CameraController, snap_world_point
 from .config import Settings
-from .game_state import AppView, GamePhase, GameState, StateManager
 from .movement_input import MovementInputState
+from .state_manager import AppView, GamePhase, StateManager

--- a/src/sv/core/__init__.py
+++ b/src/sv/core/__init__.py
@@ -1,5 +1,5 @@
 """Core systems (config, game state)."""
 from .camera_controller import CameraController, snap_world_point
 from .config import Settings
-from .game_state import GameState
+from .game_state import AppView, GamePhase, GameState, StateManager
 from .movement_input import MovementInputState

--- a/src/sv/core/game_state.py
+++ b/src/sv/core/game_state.py
@@ -1,6 +1,0 @@
-from .state_manager import AppView, GamePhase, StateManager
-
-
-GameState = StateManager
-
-__all__ = ["AppView", "GamePhase", "GameState", "StateManager"]

--- a/src/sv/core/game_state.py
+++ b/src/sv/core/game_state.py
@@ -1,4 +1,6 @@
-class GameState:
-    def __init__(self, settings):
-        self.settings = settings
-        self.running = True
+from .state_manager import AppView, GamePhase, StateManager
+
+
+GameState = StateManager
+
+__all__ = ["AppView", "GamePhase", "GameState", "StateManager"]

--- a/src/sv/core/state_manager.py
+++ b/src/sv/core/state_manager.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+class AppView(Enum):
+    MAIN_MENU = auto()
+    IN_GAME = auto()
+
+
+class GamePhase(Enum):
+    PLAYER_TURN = auto()
+    PLAYER_ANIM = auto()
+    ENEMY_TURN = auto()
+    PAUSED = auto()
+
+
+@dataclass
+class StateManager:
+    view: AppView = AppView.MAIN_MENU
+    phase: GamePhase | None = None
+    _phase_before_pause: GamePhase | None = None
+
+    def is_in_game(self) -> bool:
+        return self.view is AppView.IN_GAME
+
+    def is_main_menu(self) -> bool:
+        return self.view is AppView.MAIN_MENU
+
+    def is_player_turn(self) -> bool:
+        return self.phase is GamePhase.PLAYER_TURN
+
+    def is_player_anim(self) -> bool:
+        return self.phase is GamePhase.PLAYER_ANIM
+
+    def is_enemy_turn(self) -> bool:
+        return self.phase is GamePhase.ENEMY_TURN
+
+    def is_paused(self) -> bool:
+        return self.phase is GamePhase.PAUSED
+
+    def enter_main_menu(self) -> None:
+        self.view = AppView.MAIN_MENU
+        self.phase = None
+        self._phase_before_pause = None
+
+    def enter_game(self, initial_phase: GamePhase = GamePhase.PLAYER_TURN) -> None:
+        self.view = AppView.IN_GAME
+        self.phase = initial_phase
+        self._phase_before_pause = None
+
+    def set_phase(self, phase: GamePhase) -> None:
+        if not self.is_in_game():
+            return
+        if phase is GamePhase.PAUSED:
+            self._phase_before_pause = self.phase
+        elif phase is not self.phase:
+            self._phase_before_pause = None
+        self.phase = phase
+
+    def toggle_pause(self) -> bool:
+        if not self.is_in_game():
+            return False
+        if self.is_paused():
+            if self._phase_before_pause is None:
+                return False
+            self.phase = self._phase_before_pause
+            self._phase_before_pause = None
+            return True
+        if self.phase is None:
+            return False
+        self._phase_before_pause = self.phase
+        self.phase = GamePhase.PAUSED
+        return True

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,90 @@
+import sys
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from sv.core.state_manager import AppView, GamePhase, StateManager
+
+
+class StateManagerTests(unittest.TestCase):
+    def test_defaults_to_main_menu_without_phase(self):
+        state = StateManager()
+
+        self.assertEqual(state.view, AppView.MAIN_MENU)
+        self.assertIsNone(state.phase)
+        self.assertTrue(state.is_main_menu())
+        self.assertFalse(state.is_in_game())
+
+    def test_enter_game_sets_in_game_player_turn(self):
+        state = StateManager()
+
+        state.enter_game()
+
+        self.assertEqual(state.view, AppView.IN_GAME)
+        self.assertEqual(state.phase, GamePhase.PLAYER_TURN)
+        self.assertTrue(state.is_player_turn())
+
+    def test_set_phase_is_no_op_outside_game(self):
+        state = StateManager()
+
+        state.set_phase(GamePhase.ENEMY_TURN)
+
+        self.assertIsNone(state.phase)
+        self.assertTrue(state.is_main_menu())
+
+    def test_set_phase_changes_phase_in_game(self):
+        state = StateManager()
+        state.enter_game()
+
+        state.set_phase(GamePhase.ENEMY_TURN)
+
+        self.assertEqual(state.phase, GamePhase.ENEMY_TURN)
+        self.assertTrue(state.is_enemy_turn())
+
+    def test_enter_main_menu_clears_game_phase(self):
+        state = StateManager()
+        state.enter_game(GamePhase.ENEMY_TURN)
+
+        state.enter_main_menu()
+
+        self.assertEqual(state.view, AppView.MAIN_MENU)
+        self.assertIsNone(state.phase)
+        self.assertTrue(state.is_main_menu())
+
+    def test_toggle_pause_is_no_op_in_main_menu(self):
+        state = StateManager()
+
+        changed = state.toggle_pause()
+
+        self.assertFalse(changed)
+        self.assertEqual(state.view, AppView.MAIN_MENU)
+        self.assertIsNone(state.phase)
+
+    def test_toggle_pause_round_trips_player_turn(self):
+        state = StateManager()
+        state.enter_game()
+
+        paused = state.toggle_pause()
+        resumed = state.toggle_pause()
+
+        self.assertTrue(paused)
+        self.assertTrue(resumed)
+        self.assertEqual(state.phase, GamePhase.PLAYER_TURN)
+
+    def test_toggle_pause_restores_previous_phase(self):
+        state = StateManager()
+        state.enter_game(GamePhase.ENEMY_TURN)
+
+        state.toggle_pause()
+        state.toggle_pause()
+
+        self.assertEqual(state.phase, GamePhase.ENEMY_TURN)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Что сделано
Реализация первоначального state manager для управления верхнеуровневым состоянием приложения и фазами игрового процесса.

## Основные изменения
- добавлен `StateManager` для управления состоянием приложения и игровыми фазами
- реализованы `AppView` (`MAIN_MENU`, `IN_GAME`) и `GamePhase` (`PLAYER_TURN`, `PLAYER_ANIM`, `ENEMY_TURN`, `PAUSED`)
- игровой цикл переведён со строкового `self.turn` на явный state manager
- переходы между фазами игрока и врагов сделаны через `GamePhase`
- добавлена логическая пауза по `ESC` с возвратом в предыдущую фазу
- созданы unit-тесты для state manager

## Что сюда не входит
- полноценный UI главного меню
- визуальный overlay для паузы
- новые gameplay-состояния вроде `PLAYER_DEAD`, `VICTORY`, `INVENTORY`
