### PR TITLE
add main and pause menu, modular menu navigation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ import time
 from collections import deque
 from pathlib import Path
 import arcade
+from arcade import gui
 from arcade import gl
 from arcade.future.light import Light, LightLayer
 from sv.core import (
@@ -18,7 +19,7 @@ from sv.world import LevelGenerator
 from sv.entities import Player, Skeleton
 from sv.ai import decide_enemy_action
 from sv.core.collision import MoveResult
-from sv.ui import ProgressBar
+from sv.ui import GameUI, HUDLayer, OverlayScreenId
 
 TILE_SIZE = Settings.TILE_SIZE
 PLAYER_INPUT_DIAGONAL_WINDOW = 0.02
@@ -53,9 +54,13 @@ class Game(arcade.Window):
             title=self.settings.title
         )
 
-        # HUD, etc
-        self.ui = arcade.gui.UIManager()
-        self.ui.enable()
+        self.ui_manager = gui.UIManager()
+        self.ui = GameUI(
+            self.ui_manager,
+            HUDLayer(),
+            on_resume=self._resume_game,
+            on_main_menu=self._return_to_main_menu,
+        )
         
         self.level = None
         self.scene = None
@@ -64,7 +69,6 @@ class Game(arcade.Window):
         self.camera_controller = None
         self.light_layer = None
         self.player_light = None
-        self.light_pbar = None
         self.state = StateManager()
         # Очередь врагов для последовательной обработки
         self._enemy_queue: deque = deque()
@@ -159,22 +163,6 @@ class Game(arcade.Window):
         else:
             skeleton = Skeleton(tile_x=spawn_xy[0] + 1, tile_y=spawn_xy[1])
         self.scene.add_sprite("Skeleton", skeleton)
-        
-        # Создаем hud bar
-
-        # Инициализируем подложку
-        self.hud_anchor = arcade.gui.UIAnchorLayout()
-        self.bars_layout = arcade.gui.UIBoxLayout(vertical=False, 
-                                                  space_between=20, align="center")
-        # Инициализируем бар и добавляем в подложку
-        self.pbar = ProgressBar(color=arcade.color.RED, 
-                                value=1.0, width=200, height=15)
-        self.bars_layout.add(self.pbar)
-        self.light_pbar = ProgressBar(color=arcade.color.GOLD, 
-                                       value=1.0, width=200, height=15)
-        self.bars_layout.add(self.light_pbar)
-        self.hud_anchor.add(self.bars_layout, anchor_x="left", 
-                            anchor_y="bottom", align_y=10, align_x=8)
 
         # Подключаем базовый световой слой через arcade.gl
         self.light_layer = LightLayer(self.settings.screen_width, self.settings.screen_height)
@@ -188,8 +176,7 @@ class Game(arcade.Window):
         )
         self.light_layer.add(self.player_light)
 
-        # Добавляем подложку в UI
-        self.ui.add(self.hud_anchor)
+        self.ui.setup()
         self.state.enter_game()
 
     def on_resize(self, width, height):
@@ -210,13 +197,12 @@ class Game(arcade.Window):
         self.ui.draw()
 
     def on_update(self, delta_time):
-        # Обновляем значение hp(хп * флоат_значение)
-        self.pbar.value = self.player_sprite.hp / self.player_sprite.max_hp
-        self.pbar.update_bar()
-        self.light_pbar.value = self._player_light_ratio()
-        self.light_pbar.update_bar()
+        self.ui.update_hud(
+            self.player_sprite.hp / self.player_sprite.max_hp,
+            self._player_light_ratio(),
+        )
 
-        if self.state.is_paused():
+        if not self.state.is_in_game() or self.state.is_paused():
             return
 
         # Обновляем сцену, чтобы вызвать Sprite.update на всех спрайтах (анимация движения)
@@ -290,6 +276,16 @@ class Game(arcade.Window):
         return None
 
     def on_key_press(self, symbol, modifiers):
+        if self.ui.handle_key_press(symbol, modifiers):
+            return
+
+        if symbol == arcade.key.ESCAPE:
+            self._pause_game()
+            return
+
+        if not self.state.is_in_game():
+            return
+
         # Зум камеры, не должен зависеть от порядка ходов.
         if symbol in (arcade.key.PLUS, arcade.key.EQUAL):
             if self.camera_controller is not None:
@@ -299,13 +295,8 @@ class Game(arcade.Window):
             if self.camera_controller is not None:
                 self.camera_controller.zoom_out()
             return
-        if symbol == arcade.key.ESCAPE:
-            self.state.toggle_pause()
-            return
 
         now = time.time()
-        if self.state.is_paused():
-            return
 
         if symbol in PLAYER_DIRECTION_KEYS:
             self.movement_input.press(symbol, now)
@@ -357,6 +348,8 @@ class Game(arcade.Window):
         return res, blocker
 
     def on_key_release(self, symbol, modifiers):
+        if not self.state.is_in_game() or self.ui.has_active_overlay():
+            return
         self.movement_input.release(symbol, time.time())
 
     def _process_player_movement(self, now: float):
@@ -446,6 +439,23 @@ class Game(arcade.Window):
 
         # Очередь пуста — возвращаем ход игроку
         self.state.set_phase(GamePhase.PLAYER_TURN)
+
+    def _pause_game(self) -> None:
+        if not self.state.pause():
+            return
+        self.movement_input.clear()
+        self.ui.show_screen(OverlayScreenId.PAUSE)
+
+    def _resume_game(self) -> None:
+        if not self.state.resume():
+            return
+        self.movement_input.clear()
+        self.ui.clear_overlay()
+
+    def _return_to_main_menu(self) -> None:
+        self.state.enter_main_menu()
+        self.movement_input.clear()
+        self.ui.clear_overlay()
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ from sv.world import LevelGenerator
 from sv.entities import Player, Skeleton
 from sv.ai import decide_enemy_action
 from sv.core.collision import MoveResult
-from sv.ui import GameUI, HUDLayer, OverlayScreenId
+from sv.ui import GameUI, HUDLayer, OverlayScreenId, ViewScreenId
 
 TILE_SIZE = Settings.TILE_SIZE
 PLAYER_INPUT_DIAGONAL_WINDOW = 0.02
@@ -60,6 +60,8 @@ class Game(arcade.Window):
             HUDLayer(),
             on_resume=self._resume_game,
             on_main_menu=self._return_to_main_menu,
+            on_new_game=self.start_new_game,
+            on_exit_game=self.close,
         )
         
         self.level = None
@@ -80,6 +82,17 @@ class Game(arcade.Window):
         )
 
     def setup(self):
+        self.ui.setup()
+        self.start_new_game()
+
+    def start_new_game(self) -> None:
+        self.ui.clear_view_screen()
+        self.ui.clear_overlay()
+        self.ui.set_hud_visible(True)
+        self.movement_input.clear()
+        self._enemy_queue.clear()
+        self._current_enemy = None
+
         # Генерируем уровень (BSP: 0=void, 1=floor, 2=wall, 3=stairs)
         gen = LevelGenerator(width=64, height=48)
         level, spawn_xy, stairs_xy = gen.generate()
@@ -176,7 +189,6 @@ class Game(arcade.Window):
         )
         self.light_layer.add(self.player_light)
 
-        self.ui.setup()
         self.state.enter_game()
 
     def on_resize(self, width, height):
@@ -190,17 +202,19 @@ class Game(arcade.Window):
 
     def on_draw(self):
         self.clear()
-        with self.light_layer:
-            self.camera.use()
-            self.scene.draw()
-        self.light_layer.draw(ambient_color=(28, 24, 34, 255))
+        if self.state.is_in_game() and self.light_layer is not None and self.camera is not None and self.scene is not None:
+            with self.light_layer:
+                self.camera.use()
+                self.scene.draw()
+            self.light_layer.draw(ambient_color=(28, 24, 34, 255))
         self.ui.draw()
 
     def on_update(self, delta_time):
-        self.ui.update_hud(
-            self.player_sprite.hp / self.player_sprite.max_hp,
-            self._player_light_ratio(),
-        )
+        if self.state.is_in_game() and self.player_sprite is not None:
+            self.ui.update_hud(
+                self.player_sprite.hp / self.player_sprite.max_hp,
+                self._player_light_ratio(),
+            )
 
         if not self.state.is_in_game() or self.state.is_paused():
             return
@@ -257,6 +271,8 @@ class Game(arcade.Window):
 
     def get_entity_at(self, tile_x: int, tile_y: int, list_name: str | None = None):
         """Возвращает сущность в списке по координатам тайла, либо None."""
+        if self.scene is None:
+            return None
         # Если указано имя списка - ищем только в нём
         if list_name:
             sprites = self.scene.get_sprite_list(list_name)
@@ -380,7 +396,7 @@ class Game(arcade.Window):
 
     def process_enemy_turns(self):
         """Запускает последовательную обработку ходов всех врагов с ожиданием их анимаций."""
-        if self.state.is_paused():
+        if self.state.is_paused() or self.scene is None:
             return
         # Сформируем очередь живых врагов
         enemies = list(self.scene.get_sprite_list("Skeleton") or [])
@@ -456,6 +472,8 @@ class Game(arcade.Window):
         self.state.enter_main_menu()
         self.movement_input.clear()
         self.ui.clear_overlay()
+        self.ui.set_hud_visible(False)
+        self.ui.show_view_screen(ViewScreenId.MAIN_MENU)
 
 
 def main():

--- a/src/sv/core/movement_input.py
+++ b/src/sv/core/movement_input.py
@@ -66,6 +66,17 @@ class MovementInputState:
     def clear_blocked_on_input_change(self) -> None:
         self._blocked_move = None
 
+    def clear(self) -> None:
+        self._pressed_keys.clear()
+        self._press_times.clear()
+        self._press_order.clear()
+        self._order_counter = 0
+        self._initial_move = None
+        self._held_move = None
+        self._ready_at = 0.0
+        self._initial_move_consumed = True
+        self._blocked_move = None
+
     def _refresh_resolution(
         self,
         now: float,

--- a/src/sv/core/state_manager.py
+++ b/src/sv/core/state_manager.py
@@ -63,13 +63,19 @@ class StateManager:
         if not self.is_in_game():
             return False
         if self.is_paused():
-            if self._phase_before_pause is None:
-                return False
-            self.phase = self._phase_before_pause
-            self._phase_before_pause = None
-            return True
-        if self.phase is None:
+            return self.resume()
+        return self.pause()
+
+    def pause(self) -> bool:
+        if not self.is_in_game() or self.phase is None or self.is_paused():
             return False
         self._phase_before_pause = self.phase
         self.phase = GamePhase.PAUSED
+        return True
+
+    def resume(self) -> bool:
+        if not self.is_paused() or self._phase_before_pause is None:
+            return False
+        self.phase = self._phase_before_pause
+        self._phase_before_pause = None
         return True

--- a/src/sv/ui/__init__.py
+++ b/src/sv/ui/__init__.py
@@ -1,3 +1,3 @@
 """User interface drawing."""
 from .hud import HUDLayer, ProgressBar
-from .overlay import GameUI, OverlayScreenId, OverlayStack
+from .overlay import GameUI, OverlayScreenId, ScreenStack, ViewScreenId

--- a/src/sv/ui/__init__.py
+++ b/src/sv/ui/__init__.py
@@ -1,2 +1,3 @@
 """User interface drawing."""
-from .hud import ProgressBar
+from .hud import HUDLayer, ProgressBar
+from .overlay import GameUI, OverlayScreenId, OverlayStack

--- a/src/sv/ui/hud.py
+++ b/src/sv/ui/hud.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import arcade
 from arcade import gui
 
 
-class ProgressBar(arcade.gui.UIAnchorLayout):
-    value = arcade.gui.Property(0.0)
+class ProgressBar(gui.UIAnchorLayout):
+    value = gui.Property(0.0)
 
     def __init__(
         self,
@@ -16,11 +18,48 @@ class ProgressBar(arcade.gui.UIAnchorLayout):
         self.with_background(color=arcade.uicolor.GRAY_CONCRETE)
         self.with_border(color=arcade.uicolor.BLACK)
 
-        self._bar = arcade.gui.UISpace(color=color, size_hint=(value, 1))
+        self._bar = gui.UISpace(color=color, size_hint=(value, 1))
         self.add(self._bar, anchor_x="left", anchor_y="top")
         self.value = value
-        arcade.gui.bind(self, "value", self.trigger_render)
+        gui.bind(self, "value", self.trigger_render)
 
-    def update_bar(self):
+    def update_bar(self) -> None:
         self._bar.size_hint = (self.value, 1)
         self._bar.visible = self.value > 0
+
+
+class HUDLayer:
+    def __init__(self) -> None:
+        self.root = gui.UIAnchorLayout()
+        bars_layout = gui.UIBoxLayout(vertical=False, space_between=20, align="center")
+
+        self.health_bar = ProgressBar(
+            color=arcade.color.RED,
+            value=1.0,
+            width=200,
+            height=15,
+        )
+        bars_layout.add(self.health_bar)
+
+        self.light_bar = ProgressBar(
+            color=arcade.color.GOLD,
+            value=1.0,
+            width=200,
+            height=15,
+        )
+        bars_layout.add(self.light_bar)
+
+        self.root.add(
+            bars_layout,
+            anchor_x="left",
+            anchor_y="bottom",
+            align_x=8,
+            align_y=10,
+        )
+
+    def update(self, health_ratio: float, light_ratio: float) -> None:
+        self.health_bar.value = max(0.0, min(1.0, health_ratio))
+        self.health_bar.update_bar()
+
+        self.light_bar.value = max(0.0, min(1.0, light_ratio))
+        self.light_bar.update_bar()

--- a/src/sv/ui/overlay.py
+++ b/src/sv/ui/overlay.py
@@ -9,6 +9,11 @@ import arcade
 from arcade import gui
 
 
+class ViewScreenId(str, Enum):
+    MAIN_MENU = "main_menu"
+    SETTINGS = "settings"
+
+
 class OverlayScreenId(str, Enum):
     PAUSE = "pause"
     SETTINGS = "settings"
@@ -21,13 +26,13 @@ class MenuAction:
 
 
 @dataclass
-class OverlayStack:
-    _items: list[OverlayScreenId] = field(default_factory=list)
+class ScreenStack:
+    _items: list[Enum] = field(default_factory=list)
 
-    def push(self, screen_id: OverlayScreenId) -> None:
+    def push(self, screen_id: Enum) -> None:
         self._items.append(screen_id)
 
-    def pop(self) -> OverlayScreenId | None:
+    def pop(self) -> Enum | None:
         if not self._items:
             return None
         return self._items.pop()
@@ -35,7 +40,7 @@ class OverlayStack:
     def clear(self) -> None:
         self._items.clear()
 
-    def current(self) -> OverlayScreenId | None:
+    def current(self) -> Enum | None:
         if not self._items:
             return None
         return self._items[-1]
@@ -47,24 +52,49 @@ class OverlayStack:
         return not self._items
 
 
-class OverlayScreen:
-    BUTTON_WIDTH = 240
-    BUTTON_HEIGHT = 44
-    PANEL_WIDTH = 360
-    PANEL_HEIGHT = 280
+@dataclass(frozen=True)
+class MenuVisualSpec:
+    button_width: int
+    button_height: int
+    panel_width: int
+    panel_height: int
+    title_font_size: int
+    overlay_color: arcade.types.Color
 
-    def __init__(self, screen_id: OverlayScreenId, title: str, actions: list[MenuAction]):
+
+OVERLAY_VISUAL_SPEC = MenuVisualSpec(
+    button_width=240,
+    button_height=44,
+    panel_width=360,
+    panel_height=280,
+    title_font_size=24,
+    overlay_color=(4, 6, 10, 190),
+)
+
+VIEW_VISUAL_SPEC = MenuVisualSpec(
+    button_width=280,
+    button_height=48,
+    panel_width=420,
+    panel_height=340,
+    title_font_size=40,
+    overlay_color=(8, 10, 16, 255),
+)
+
+
+class MenuScreen:
+    def __init__(self, screen_id: Enum, title: str, actions: list[MenuAction], visual: MenuVisualSpec):
         self.screen_id = screen_id
         self.title = title
         self.actions = actions
+        self.visual = visual
 
     def build(self) -> tuple[gui.UIAnchorLayout, list[gui.UIFlatButton]]:
         root = gui.UIAnchorLayout()
-        root.add(gui.UISpace(color=(4, 6, 10, 190), size_hint=(1, 1)))
+        root.add(gui.UISpace(color=self.visual.overlay_color, size_hint=(1, 1)))
 
         panel = gui.UIAnchorLayout(
-            width=self.PANEL_WIDTH,
-            height=self.PANEL_HEIGHT,
+            width=self.visual.panel_width,
+            height=self.visual.panel_height,
             size_hint=None,
         )
         panel.with_background(color=(20, 22, 28, 235))
@@ -74,9 +104,9 @@ class OverlayScreen:
         content.add(
             gui.UILabel(
                 text=self.title,
-                width=self.BUTTON_WIDTH,
+                width=self.visual.button_width,
                 align="center",
-                font_size=24,
+                font_size=self.visual.title_font_size,
                 bold=True,
             )
         )
@@ -85,8 +115,8 @@ class OverlayScreen:
         for action in self.actions:
             button = gui.UIFlatButton(
                 text=action.label,
-                width=self.BUTTON_WIDTH,
-                height=self.BUTTON_HEIGHT,
+                width=self.visual.button_width,
+                height=self.visual.button_height,
                 style=_menu_button_style(),
             )
 
@@ -102,7 +132,26 @@ class OverlayScreen:
         return root, buttons
 
 
-class PauseMenuScreen(OverlayScreen):
+class MainMenuScreen(MenuScreen):
+    def __init__(
+        self,
+        on_new_game: Callable[[], None],
+        on_open_settings: Callable[[], None],
+        on_exit_game: Callable[[], None],
+    ):
+        super().__init__(
+            ViewScreenId.MAIN_MENU,
+            "Shardveil",
+            [
+                MenuAction("Новая игра", on_new_game),
+                MenuAction("Настройки", on_open_settings),
+                MenuAction("Выйти из игры", on_exit_game),
+            ],
+            VIEW_VISUAL_SPEC,
+        )
+
+
+class PauseMenuScreen(MenuScreen):
     def __init__(
         self,
         on_resume: Callable[[], None],
@@ -117,15 +166,17 @@ class PauseMenuScreen(OverlayScreen):
                 MenuAction("Настройки", on_open_settings),
                 MenuAction("Главное меню", on_main_menu),
             ],
+            OVERLAY_VISUAL_SPEC,
         )
 
 
-class SettingsScreen(OverlayScreen):
-    def __init__(self, on_back: Callable[[], None]):
+class SettingsScreen(MenuScreen):
+    def __init__(self, on_back: Callable[[], None], *, visual: MenuVisualSpec):
         super().__init__(
-            OverlayScreenId.SETTINGS,
+            ViewScreenId.SETTINGS if visual is VIEW_VISUAL_SPEC else OverlayScreenId.SETTINGS,
             "Настройки",
             [MenuAction("Назад", on_back)],
+            visual,
         )
 
 
@@ -137,19 +188,32 @@ class GameUI:
         *,
         on_resume: Callable[[], None],
         on_main_menu: Callable[[], None],
+        on_new_game: Callable[[], None],
+        on_exit_game: Callable[[], None],
     ) -> None:
         self.manager = manager
         self.hud_layer = hud_layer
         self.on_resume = on_resume
         self.on_main_menu = on_main_menu
-        self.overlay_stack = OverlayStack()
+        self.on_new_game = on_new_game
+        self.on_exit_game = on_exit_game
+        self.overlay_stack: ScreenStack = ScreenStack()
+        self.view_stack: ScreenStack = ScreenStack()
         self._active_overlay: gui.UIWidget | None = None
-        self._current_screen: OverlayScreen | None = None
-        self._buttons: list[gui.UIFlatButton] = []
-        self._selected_index = 0
-        self._screen_factories = {
+        self._active_view: gui.UIWidget | None = None
+        self._current_overlay_screen: MenuScreen | None = None
+        self._current_view_screen: MenuScreen | None = None
+        self._overlay_buttons: list[gui.UIFlatButton] = []
+        self._view_buttons: list[gui.UIFlatButton] = []
+        self._overlay_selected_index = 0
+        self._view_selected_index = 0
+        self._overlay_factories = {
             OverlayScreenId.PAUSE: self._build_pause_screen,
-            OverlayScreenId.SETTINGS: self._build_settings_screen,
+            OverlayScreenId.SETTINGS: self._build_overlay_settings_screen,
+        }
+        self._view_factories = {
+            ViewScreenId.MAIN_MENU: self._build_main_menu_screen,
+            ViewScreenId.SETTINGS: self._build_view_settings_screen,
         }
 
     def setup(self) -> None:
@@ -159,8 +223,36 @@ class GameUI:
     def draw(self) -> None:
         self.manager.draw()
 
+    def set_hud_visible(self, visible: bool) -> None:
+        self.hud_layer.root.visible = visible
+
     def update_hud(self, health_ratio: float, light_ratio: float) -> None:
         self.hud_layer.update(health_ratio, light_ratio)
+
+    def show_view_screen(self, screen_id: ViewScreenId) -> None:
+        self.clear_overlay()
+        self.view_stack.clear()
+        self.view_stack.push(screen_id)
+        self._render_view_screen()
+
+    def push_view_screen(self, screen_id: ViewScreenId) -> None:
+        self.view_stack.push(screen_id)
+        self._render_view_screen()
+
+    def pop_view_screen(self) -> ViewScreenId | None:
+        popped = self.view_stack.pop()
+        self._render_view_screen()
+        return popped
+
+    def clear_view_screen(self) -> None:
+        self.view_stack.clear()
+        self._remove_active_view()
+        self._current_view_screen = None
+        self._view_buttons = []
+        self._view_selected_index = 0
+
+    def has_active_view(self) -> bool:
+        return not self.view_stack.is_empty()
 
     def has_active_overlay(self) -> bool:
         return not self.overlay_stack.is_empty()
@@ -171,75 +263,106 @@ class GameUI:
 
     def push_screen(self, screen_id: OverlayScreenId) -> None:
         self.overlay_stack.push(screen_id)
-        self._render_current_screen()
+        self._render_overlay_screen()
 
     def pop_screen(self) -> OverlayScreenId | None:
         popped = self.overlay_stack.pop()
-        self._render_current_screen()
+        self._render_overlay_screen()
         return popped
 
     def clear_overlay(self) -> None:
         self.overlay_stack.clear()
         self._remove_active_overlay()
-        self._current_screen = None
-        self._buttons = []
-        self._selected_index = 0
+        self._current_overlay_screen = None
+        self._overlay_buttons = []
+        self._overlay_selected_index = 0
 
     def handle_key_press(self, symbol: int, modifiers: int) -> bool:
-        if not self.has_active_overlay():
-            return False
+        if self.has_active_overlay():
+            return self._handle_overlay_key_press(symbol)
+        if self.has_active_view():
+            return self._handle_view_key_press(symbol)
+        return False
 
+    def _handle_overlay_key_press(self, symbol: int) -> bool:
         if symbol == arcade.key.ESCAPE:
             if self.overlay_stack.depth() > 1:
                 self.pop_screen()
             else:
                 self.on_resume()
             return True
+        return self._handle_menu_navigation(symbol, overlay=True)
 
+    def _handle_view_key_press(self, symbol: int) -> bool:
+        return self._handle_menu_navigation(symbol, overlay=False)
+
+    def _handle_menu_navigation(self, symbol: int, *, overlay: bool) -> bool:
         if symbol in (arcade.key.UP, arcade.key.W):
-            self._move_selection(-1)
+            self._move_selection(-1, overlay=overlay)
             return True
-
         if symbol in (arcade.key.DOWN, arcade.key.S):
-            self._move_selection(1)
+            self._move_selection(1, overlay=overlay)
             return True
-
         if symbol in (arcade.key.ENTER, arcade.key.SPACE):
-            self._activate_selected()
+            self._activate_selected(overlay=overlay)
             return True
-
         return False
 
-    def _move_selection(self, step: int) -> None:
-        if not self._buttons:
+    def _move_selection(self, step: int, *, overlay: bool) -> None:
+        buttons = self._overlay_buttons if overlay else self._view_buttons
+        if not buttons:
             return
-        self._selected_index = (self._selected_index + step) % len(self._buttons)
-        self._refresh_button_labels()
+        if overlay:
+            self._overlay_selected_index = (self._overlay_selected_index + step) % len(buttons)
+            self._refresh_button_labels(overlay=True)
+        else:
+            self._view_selected_index = (self._view_selected_index + step) % len(buttons)
+            self._refresh_button_labels(overlay=False)
 
-    def _activate_selected(self) -> None:
-        if self._current_screen is None or not self._current_screen.actions:
+    def _activate_selected(self, *, overlay: bool) -> None:
+        screen = self._current_overlay_screen if overlay else self._current_view_screen
+        index = self._overlay_selected_index if overlay else self._view_selected_index
+        if screen is None or not screen.actions:
             return
-        self._current_screen.actions[self._selected_index].callback()
+        screen.actions[index].callback()
 
-    def _render_current_screen(self) -> None:
+    def _render_overlay_screen(self) -> None:
         self._remove_active_overlay()
 
         current_id = self.overlay_stack.current()
         if current_id is None:
-            self._current_screen = None
-            self._buttons = []
-            self._selected_index = 0
+            self._current_overlay_screen = None
+            self._overlay_buttons = []
+            self._overlay_selected_index = 0
             return
 
-        screen = self._screen_factories[current_id]()
+        screen = self._overlay_factories[current_id]()
         root, buttons = screen.build()
         self.manager.add(root)
-
         self._active_overlay = root
-        self._current_screen = screen
-        self._buttons = buttons
-        self._selected_index = 0
-        self._refresh_button_labels()
+        self._current_overlay_screen = screen
+        self._overlay_buttons = buttons
+        self._overlay_selected_index = 0
+        self._refresh_button_labels(overlay=True)
+
+    def _render_view_screen(self) -> None:
+        self._remove_active_view()
+
+        current_id = self.view_stack.current()
+        if current_id is None:
+            self._current_view_screen = None
+            self._view_buttons = []
+            self._view_selected_index = 0
+            return
+
+        screen = self._view_factories[current_id]()
+        root, buttons = screen.build()
+        self.manager.add(root)
+        self._active_view = root
+        self._current_view_screen = screen
+        self._view_buttons = buttons
+        self._view_selected_index = 0
+        self._refresh_button_labels(overlay=False)
 
     def _remove_active_overlay(self) -> None:
         if self._active_overlay is None:
@@ -247,13 +370,35 @@ class GameUI:
         self.manager.remove(self._active_overlay)
         self._active_overlay = None
 
-    def _refresh_button_labels(self) -> None:
-        if self._current_screen is None:
+    def _remove_active_view(self) -> None:
+        if self._active_view is None:
             return
-        for index, button in enumerate(self._buttons):
-            label = self._current_screen.actions[index].label
-            button.text = f"> {label} <" if index == self._selected_index else label
+        self.manager.remove(self._active_view)
+        self._active_view = None
+
+    def _refresh_button_labels(self, *, overlay: bool) -> None:
+        if overlay:
+            screen = self._current_overlay_screen
+            buttons = self._overlay_buttons
+            selected_index = self._overlay_selected_index
+        else:
+            screen = self._current_view_screen
+            buttons = self._view_buttons
+            selected_index = self._view_selected_index
+
+        if screen is None:
+            return
+        for index, button in enumerate(buttons):
+            label = screen.actions[index].label
+            button.text = f"> {label} <" if index == selected_index else label
             button.trigger_full_render()
+
+    def _build_main_menu_screen(self) -> MainMenuScreen:
+        return MainMenuScreen(
+            on_new_game=self.on_new_game,
+            on_open_settings=lambda: self.push_view_screen(ViewScreenId.SETTINGS),
+            on_exit_game=self.on_exit_game,
+        )
 
     def _build_pause_screen(self) -> PauseMenuScreen:
         return PauseMenuScreen(
@@ -262,8 +407,11 @@ class GameUI:
             on_main_menu=self.on_main_menu,
         )
 
-    def _build_settings_screen(self) -> SettingsScreen:
-        return SettingsScreen(on_back=self.pop_screen)
+    def _build_overlay_settings_screen(self) -> SettingsScreen:
+        return SettingsScreen(on_back=self.pop_screen, visual=OVERLAY_VISUAL_SPEC)
+
+    def _build_view_settings_screen(self) -> SettingsScreen:
+        return SettingsScreen(on_back=self.pop_view_screen, visual=VIEW_VISUAL_SPEC)
 
 
 def _menu_button_style() -> dict[str, dict[str, object]]:

--- a/src/sv/ui/overlay.py
+++ b/src/sv/ui/overlay.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import dataclass, field
+from enum import Enum
+
+import arcade
+from arcade import gui
+
+
+class OverlayScreenId(str, Enum):
+    PAUSE = "pause"
+    SETTINGS = "settings"
+
+
+@dataclass(frozen=True)
+class MenuAction:
+    label: str
+    callback: Callable[[], None]
+
+
+@dataclass
+class OverlayStack:
+    _items: list[OverlayScreenId] = field(default_factory=list)
+
+    def push(self, screen_id: OverlayScreenId) -> None:
+        self._items.append(screen_id)
+
+    def pop(self) -> OverlayScreenId | None:
+        if not self._items:
+            return None
+        return self._items.pop()
+
+    def clear(self) -> None:
+        self._items.clear()
+
+    def current(self) -> OverlayScreenId | None:
+        if not self._items:
+            return None
+        return self._items[-1]
+
+    def depth(self) -> int:
+        return len(self._items)
+
+    def is_empty(self) -> bool:
+        return not self._items
+
+
+class OverlayScreen:
+    BUTTON_WIDTH = 240
+    BUTTON_HEIGHT = 44
+    PANEL_WIDTH = 360
+    PANEL_HEIGHT = 280
+
+    def __init__(self, screen_id: OverlayScreenId, title: str, actions: list[MenuAction]):
+        self.screen_id = screen_id
+        self.title = title
+        self.actions = actions
+
+    def build(self) -> tuple[gui.UIAnchorLayout, list[gui.UIFlatButton]]:
+        root = gui.UIAnchorLayout()
+        root.add(gui.UISpace(color=(4, 6, 10, 190), size_hint=(1, 1)))
+
+        panel = gui.UIAnchorLayout(
+            width=self.PANEL_WIDTH,
+            height=self.PANEL_HEIGHT,
+            size_hint=None,
+        )
+        panel.with_background(color=(20, 22, 28, 235))
+        panel.with_border(color=arcade.color.DAVY_GREY, width=2)
+
+        content = gui.UIBoxLayout(vertical=True, space_between=18, align="center")
+        content.add(
+            gui.UILabel(
+                text=self.title,
+                width=self.BUTTON_WIDTH,
+                align="center",
+                font_size=24,
+                bold=True,
+            )
+        )
+
+        buttons: list[gui.UIFlatButton] = []
+        for action in self.actions:
+            button = gui.UIFlatButton(
+                text=action.label,
+                width=self.BUTTON_WIDTH,
+                height=self.BUTTON_HEIGHT,
+                style=_menu_button_style(),
+            )
+
+            def _on_click(_event, callback: Callable[[], None] = action.callback) -> None:
+                callback()
+
+            button.on_click = _on_click
+            content.add(button)
+            buttons.append(button)
+
+        panel.add(content, anchor_x="center", anchor_y="center")
+        root.add(panel, anchor_x="center", anchor_y="center")
+        return root, buttons
+
+
+class PauseMenuScreen(OverlayScreen):
+    def __init__(
+        self,
+        on_resume: Callable[[], None],
+        on_open_settings: Callable[[], None],
+        on_main_menu: Callable[[], None],
+    ):
+        super().__init__(
+            OverlayScreenId.PAUSE,
+            "Пауза",
+            [
+                MenuAction("Продолжить", on_resume),
+                MenuAction("Настройки", on_open_settings),
+                MenuAction("Главное меню", on_main_menu),
+            ],
+        )
+
+
+class SettingsScreen(OverlayScreen):
+    def __init__(self, on_back: Callable[[], None]):
+        super().__init__(
+            OverlayScreenId.SETTINGS,
+            "Настройки",
+            [MenuAction("Назад", on_back)],
+        )
+
+
+class GameUI:
+    def __init__(
+        self,
+        manager: gui.UIManager,
+        hud_layer,
+        *,
+        on_resume: Callable[[], None],
+        on_main_menu: Callable[[], None],
+    ) -> None:
+        self.manager = manager
+        self.hud_layer = hud_layer
+        self.on_resume = on_resume
+        self.on_main_menu = on_main_menu
+        self.overlay_stack = OverlayStack()
+        self._active_overlay: gui.UIWidget | None = None
+        self._current_screen: OverlayScreen | None = None
+        self._buttons: list[gui.UIFlatButton] = []
+        self._selected_index = 0
+        self._screen_factories = {
+            OverlayScreenId.PAUSE: self._build_pause_screen,
+            OverlayScreenId.SETTINGS: self._build_settings_screen,
+        }
+
+    def setup(self) -> None:
+        self.manager.enable()
+        self.manager.add(self.hud_layer.root)
+
+    def draw(self) -> None:
+        self.manager.draw()
+
+    def update_hud(self, health_ratio: float, light_ratio: float) -> None:
+        self.hud_layer.update(health_ratio, light_ratio)
+
+    def has_active_overlay(self) -> bool:
+        return not self.overlay_stack.is_empty()
+
+    def show_screen(self, screen_id: OverlayScreenId) -> None:
+        self.clear_overlay()
+        self.push_screen(screen_id)
+
+    def push_screen(self, screen_id: OverlayScreenId) -> None:
+        self.overlay_stack.push(screen_id)
+        self._render_current_screen()
+
+    def pop_screen(self) -> OverlayScreenId | None:
+        popped = self.overlay_stack.pop()
+        self._render_current_screen()
+        return popped
+
+    def clear_overlay(self) -> None:
+        self.overlay_stack.clear()
+        self._remove_active_overlay()
+        self._current_screen = None
+        self._buttons = []
+        self._selected_index = 0
+
+    def handle_key_press(self, symbol: int, modifiers: int) -> bool:
+        if not self.has_active_overlay():
+            return False
+
+        if symbol == arcade.key.ESCAPE:
+            if self.overlay_stack.depth() > 1:
+                self.pop_screen()
+            else:
+                self.on_resume()
+            return True
+
+        if symbol in (arcade.key.UP, arcade.key.W):
+            self._move_selection(-1)
+            return True
+
+        if symbol in (arcade.key.DOWN, arcade.key.S):
+            self._move_selection(1)
+            return True
+
+        if symbol in (arcade.key.ENTER, arcade.key.SPACE):
+            self._activate_selected()
+            return True
+
+        return False
+
+    def _move_selection(self, step: int) -> None:
+        if not self._buttons:
+            return
+        self._selected_index = (self._selected_index + step) % len(self._buttons)
+        self._refresh_button_labels()
+
+    def _activate_selected(self) -> None:
+        if self._current_screen is None or not self._current_screen.actions:
+            return
+        self._current_screen.actions[self._selected_index].callback()
+
+    def _render_current_screen(self) -> None:
+        self._remove_active_overlay()
+
+        current_id = self.overlay_stack.current()
+        if current_id is None:
+            self._current_screen = None
+            self._buttons = []
+            self._selected_index = 0
+            return
+
+        screen = self._screen_factories[current_id]()
+        root, buttons = screen.build()
+        self.manager.add(root)
+
+        self._active_overlay = root
+        self._current_screen = screen
+        self._buttons = buttons
+        self._selected_index = 0
+        self._refresh_button_labels()
+
+    def _remove_active_overlay(self) -> None:
+        if self._active_overlay is None:
+            return
+        self.manager.remove(self._active_overlay)
+        self._active_overlay = None
+
+    def _refresh_button_labels(self) -> None:
+        if self._current_screen is None:
+            return
+        for index, button in enumerate(self._buttons):
+            label = self._current_screen.actions[index].label
+            button.text = f"> {label} <" if index == self._selected_index else label
+            button.trigger_full_render()
+
+    def _build_pause_screen(self) -> PauseMenuScreen:
+        return PauseMenuScreen(
+            on_resume=self.on_resume,
+            on_open_settings=lambda: self.push_screen(OverlayScreenId.SETTINGS),
+            on_main_menu=self.on_main_menu,
+        )
+
+    def _build_settings_screen(self) -> SettingsScreen:
+        return SettingsScreen(on_back=self.pop_screen)
+
+
+def _menu_button_style() -> dict[str, dict[str, object]]:
+    style = deepcopy(gui.UIFlatButton.DEFAULT_STYLE)
+    style["normal"].font_size = 14
+    style["normal"].font_color = arcade.color.WHITE
+    style["normal"].border = arcade.color.DAVY_GREY
+    style["normal"].bg = arcade.color.BLACK
+    style["hover"].font_size = 14
+    style["hover"].border = arcade.color.DAVY_GREY
+    style["hover"].bg = arcade.color.DARK_MIDNIGHT_BLUE
+    style["press"].font_size = 14
+    style["press"].border = arcade.color.DAVY_GREY
+    style["press"].bg = arcade.color.DARK_SLATE_BLUE
+    style["disabled"].font_size = 14
+    style["disabled"].font_color = arcade.color.GRAY
+    return style

--- a/tests/test_overlay_stack.py
+++ b/tests/test_overlay_stack.py
@@ -8,12 +8,12 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from sv.ui.overlay import OverlayScreenId, OverlayStack
+from sv.ui.overlay import OverlayScreenId, ScreenStack, ViewScreenId
 
 
-class OverlayStackTests(unittest.TestCase):
+class ScreenStackTests(unittest.TestCase):
     def test_push_sets_current_screen(self):
-        stack = OverlayStack()
+        stack = ScreenStack()
 
         stack.push(OverlayScreenId.PAUSE)
 
@@ -21,7 +21,7 @@ class OverlayStackTests(unittest.TestCase):
         self.assertEqual(stack.depth(), 1)
 
     def test_pop_restores_previous_screen(self):
-        stack = OverlayStack()
+        stack = ScreenStack()
         stack.push(OverlayScreenId.PAUSE)
         stack.push(OverlayScreenId.SETTINGS)
 
@@ -32,7 +32,7 @@ class OverlayStackTests(unittest.TestCase):
         self.assertEqual(stack.depth(), 1)
 
     def test_clear_empties_stack(self):
-        stack = OverlayStack()
+        stack = ScreenStack()
         stack.push(OverlayScreenId.PAUSE)
         stack.push(OverlayScreenId.SETTINGS)
 
@@ -41,6 +41,13 @@ class OverlayStackTests(unittest.TestCase):
         self.assertTrue(stack.is_empty())
         self.assertIsNone(stack.current())
         self.assertEqual(stack.depth(), 0)
+
+    def test_stack_accepts_view_screen_ids(self):
+        stack = ScreenStack()
+
+        stack.push(ViewScreenId.MAIN_MENU)
+
+        self.assertEqual(stack.current(), ViewScreenId.MAIN_MENU)
 
 
 if __name__ == "__main__":

--- a/tests/test_overlay_stack.py
+++ b/tests/test_overlay_stack.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from sv.ui.overlay import OverlayScreenId, OverlayStack
+
+
+class OverlayStackTests(unittest.TestCase):
+    def test_push_sets_current_screen(self):
+        stack = OverlayStack()
+
+        stack.push(OverlayScreenId.PAUSE)
+
+        self.assertEqual(stack.current(), OverlayScreenId.PAUSE)
+        self.assertEqual(stack.depth(), 1)
+
+    def test_pop_restores_previous_screen(self):
+        stack = OverlayStack()
+        stack.push(OverlayScreenId.PAUSE)
+        stack.push(OverlayScreenId.SETTINGS)
+
+        popped = stack.pop()
+
+        self.assertEqual(popped, OverlayScreenId.SETTINGS)
+        self.assertEqual(stack.current(), OverlayScreenId.PAUSE)
+        self.assertEqual(stack.depth(), 1)
+
+    def test_clear_empties_stack(self):
+        stack = OverlayStack()
+        stack.push(OverlayScreenId.PAUSE)
+        stack.push(OverlayScreenId.SETTINGS)
+
+        stack.clear()
+
+        self.assertTrue(stack.is_empty())
+        self.assertIsNone(stack.current())
+        self.assertEqual(stack.depth(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -85,6 +85,34 @@ class StateManagerTests(unittest.TestCase):
 
         self.assertEqual(state.phase, GamePhase.ENEMY_TURN)
 
+    def test_pause_enters_paused_state(self):
+        state = StateManager()
+        state.enter_game(GamePhase.PLAYER_ANIM)
+
+        changed = state.pause()
+
+        self.assertTrue(changed)
+        self.assertTrue(state.is_paused())
+
+    def test_resume_restores_previous_phase(self):
+        state = StateManager()
+        state.enter_game(GamePhase.ENEMY_TURN)
+        state.pause()
+
+        changed = state.resume()
+
+        self.assertTrue(changed)
+        self.assertTrue(state.is_enemy_turn())
+
+    def test_resume_is_no_op_when_not_paused(self):
+        state = StateManager()
+        state.enter_game()
+
+        changed = state.resume()
+
+        self.assertFalse(changed)
+        self.assertTrue(state.is_player_turn())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Что сделано
- окно паузы с кнопками Продолжить, Настройки, Главное меню
- базовый главный экран
- общий экран настроек с корректным возвратом в зависимости от контекста открытия
- обновлена логика состояния игры для переходов между `IN_GAME`, `PAUSED` и `MAIN_MENU`

*пока что это первоначальная заготовка