### PR TITLE
Add map item pickups and loot chests

### DIFF
--- a/src/sv/core/collision.py
+++ b/src/sv/core/collision.py
@@ -25,9 +25,10 @@ def iter_blocking_entities(scene, ignore=None):
     if scene is None:
         return
 
-    sprite_lists = getattr(scene, "sprite_lists", None)
+    sprite_lists = getattr(scene, "sprite_lists", None) or getattr(scene, "_sprite_lists", None)
     if sprite_lists:
-        for sprites in sprite_lists.values():
+        values = sprite_lists.values() if hasattr(sprite_lists, "values") else sprite_lists
+        for sprites in values:
             try:
                 for sprite in sprites:
                     if sprite is ignore:

--- a/src/sv/core/turn_controller.py
+++ b/src/sv/core/turn_controller.py
@@ -64,6 +64,9 @@ class TurnController:
                         return sprite
         return None
 
+    def get_item_at(self, tile_x: int, tile_y: int):
+        return self.get_entity_at(tile_x, tile_y, "Items")
+
     def is_player_dead(self) -> bool:
         return (
             self.player is None
@@ -84,6 +87,7 @@ class TurnController:
         if self.player_on_stairs(stairs_xy):
             self.on_depth_advance()
             return True
+        self.pick_up_at_player(manual=False)
         self.state.set_phase(GamePhase.ENEMY_TURN)
         self.process_enemy_turns()
         return True
@@ -92,6 +96,33 @@ class TurnController:
         self.message_log.push("Вы пропустили ход", "info")
         self.state.set_phase(GamePhase.ENEMY_TURN)
         self.process_enemy_turns()
+
+    def pick_up_at_player(self, *, manual: bool = True) -> bool:
+        if self.player is None:
+            return False
+
+        item = self.get_item_at(self.player.tile_x, self.player.tile_y)
+        if item is None:
+            if manual:
+                self.message_log.push("Здесь ничего нет", "info")
+            return False
+
+        inventory = getattr(self.player, "inventory", None)
+        if inventory is None or not hasattr(inventory, "add_stack"):
+            self.message_log.push("Некуда положить предмет", "info")
+            return False
+
+        result = inventory.add_stack(getattr(item, "stack", None))
+        if not result.added:
+            self.message_log.push(result.reason or "Инвентарь заполнен.", "info")
+            return False
+
+        item.remove_from_sprite_lists()
+        self.message_log.push(f"Вы подобрали {item.stack.name}", "loot")
+        if manual:
+            self.state.set_phase(GamePhase.ENEMY_TURN)
+            self.process_enemy_turns()
+        return True
 
     def move_with_fallback(self, entity, dx, dy):
         res, blocker = entity.attempt_move(dx, dy, self.level, self.scene)

--- a/src/sv/core/turn_controller.py
+++ b/src/sv/core/turn_controller.py
@@ -10,6 +10,7 @@ from sv.core.player_resources import (
     consume_player_light,
 )
 from sv.core.state_manager import GamePhase, StateManager
+from sv.items import MapItem
 
 
 class TurnController:
@@ -67,6 +68,9 @@ class TurnController:
     def get_item_at(self, tile_x: int, tile_y: int):
         return self.get_entity_at(tile_x, tile_y, "Items")
 
+    def get_chest_at(self, tile_x: int, tile_y: int):
+        return self.get_entity_at(tile_x, tile_y, "Chests")
+
     def is_player_dead(self) -> bool:
         return (
             self.player is None
@@ -102,23 +106,53 @@ class TurnController:
             return False
 
         item = self.get_item_at(self.player.tile_x, self.player.tile_y)
-        if item is None:
-            if manual:
-                self.message_log.push("Здесь ничего нет", "info")
+        if item is not None:
+            return self._collect_map_object(
+                item,
+                success_message=f"Вы подобрали {item.stack.name}",
+                manual=manual,
+            )
+
+        if manual:
+            self.message_log.push("Здесь ничего нет", "info")
+        return False
+
+    def open_chest(self, chest) -> bool:
+        if chest is None:
             return False
 
+        stack = getattr(chest, "stack", None)
+        if stack is None or self.scene is None:
+            return False
+
+        chest.remove_from_sprite_lists()
+        self.scene.add_sprite(
+            "Items",
+            MapItem(
+                stack.definition,
+                chest.tile_x,
+                chest.tile_y,
+                quantity=stack.quantity,
+            ),
+        )
+        consume_player_light(self.player, PLAYER_ACTION_LIGHT_COST)
+        self.state.set_phase(GamePhase.ENEMY_TURN)
+        self.process_enemy_turns()
+        return True
+
+    def _collect_map_object(self, obj, *, success_message: str, manual: bool) -> bool:
         inventory = getattr(self.player, "inventory", None)
         if inventory is None or not hasattr(inventory, "add_stack"):
             self.message_log.push("Некуда положить предмет", "info")
             return False
 
-        result = inventory.add_stack(getattr(item, "stack", None))
+        result = inventory.add_stack(getattr(obj, "stack", None))
         if not result.added:
             self.message_log.push(result.reason or "Инвентарь заполнен.", "info")
             return False
 
-        item.remove_from_sprite_lists()
-        self.message_log.push(f"Вы подобрали {item.stack.name}", "loot")
+        obj.remove_from_sprite_lists()
+        self.message_log.push(success_message, "loot")
         if manual:
             self.state.set_phase(GamePhase.ENEMY_TURN)
             self.process_enemy_turns()
@@ -147,6 +181,12 @@ class TurnController:
         if res == MoveResult.BLOCKED_WALL:
             return res, blocker
         if res == MoveResult.BLOCKED_ENTITY:
+            if blocker is not None and blocker is self.get_chest_at(
+                getattr(blocker, "tile_x", -1),
+                getattr(blocker, "tile_y", -1),
+            ):
+                self.open_chest(blocker)
+                return res, blocker
             if blocker is not None and hasattr(player, "attack"):
                 player.attack(blocker)
                 if getattr(blocker, "hp", 1) <= 0 or getattr(blocker, "removed", False):

--- a/src/sv/game.py
+++ b/src/sv/game.py
@@ -175,6 +175,9 @@ class Game(arcade.Window):
         if symbol == arcade.key.SPACE:
             self.player_input.wait_turn(self.player_sprite)
             return
+        if symbol == arcade.key.C:
+            self.turn_controller.pick_up_at_player()
+            return
 
     def on_key_release(self, symbol, modifiers):
         if not self.state.is_in_game() or self.ui.has_active_overlay():

--- a/src/sv/items/__init__.py
+++ b/src/sv/items/__init__.py
@@ -6,6 +6,7 @@ from .item import (
     ItemDefinition,
     ItemKind,
     ItemStack,
+    MapItem,
     load_item_textures,
 )
 from .inventory import (
@@ -13,6 +14,7 @@ from .inventory import (
     INVENTORY_COLUMNS,
     INVENTORY_ROWS,
     Inventory,
+    InventoryAddResult,
     InventoryMoveResult,
     STORAGE_COLUMNS,
     STORAGE_ROWS,
@@ -26,10 +28,12 @@ __all__ = [
     "INVENTORY_COLUMNS",
     "INVENTORY_ROWS",
     "Inventory",
+    "InventoryAddResult",
     "InventoryMoveResult",
     "ItemDefinition",
     "ItemKind",
     "ItemStack",
+    "MapItem",
     "STORAGE_COLUMNS",
     "STORAGE_ROWS",
     "create_default_inventory",

--- a/src/sv/items/__init__.py
+++ b/src/sv/items/__init__.py
@@ -5,8 +5,10 @@ from .item import (
     EquipmentSlot,
     ItemDefinition,
     ItemKind,
+    MapChest,
     ItemStack,
     MapItem,
+    load_chest_texture,
     load_item_textures,
 )
 from .inventory import (
@@ -32,10 +34,12 @@ __all__ = [
     "InventoryMoveResult",
     "ItemDefinition",
     "ItemKind",
+    "MapChest",
     "ItemStack",
     "MapItem",
     "STORAGE_COLUMNS",
     "STORAGE_ROWS",
     "create_default_inventory",
+    "load_chest_texture",
     "load_item_textures",
 ]

--- a/src/sv/items/inventory.py
+++ b/src/sv/items/inventory.py
@@ -25,6 +25,13 @@ class InventoryMoveResult:
     reason: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class InventoryAddResult:
+    added: bool
+    quantity_added: int = 0
+    reason: str | None = None
+
+
 def _empty_storage() -> list[ItemStack | None]:
     return [None for _ in range(STORAGE_SIZE)]
 
@@ -59,6 +66,43 @@ class Inventory:
 
     def get_equipment(self, slot: EquipmentSlot) -> ItemStack | None:
         return self.equipment.get(slot)
+
+    def add_stack(self, stack: ItemStack | None) -> InventoryAddResult:
+        if stack is None:
+            return InventoryAddResult(False, reason="Нечего подобрать.")
+
+        remaining = stack.quantity
+        for storage_stack in self.storage:
+            if storage_stack is None:
+                continue
+            if storage_stack.definition.item_id != stack.definition.item_id:
+                continue
+            if storage_stack.quantity >= storage_stack.definition.max_stack:
+                continue
+
+            quantity_added = min(
+                remaining,
+                storage_stack.definition.max_stack - storage_stack.quantity,
+            )
+            storage_stack.quantity += quantity_added
+            remaining -= quantity_added
+            if remaining <= 0:
+                return InventoryAddResult(True, stack.quantity)
+
+        for index, storage_stack in enumerate(self.storage):
+            if storage_stack is not None:
+                continue
+
+            quantity_added = min(remaining, stack.definition.max_stack)
+            self.storage[index] = ItemStack(stack.definition, quantity_added)
+            remaining -= quantity_added
+            if remaining <= 0:
+                return InventoryAddResult(True, stack.quantity)
+
+        added = stack.quantity - remaining
+        if added > 0:
+            return InventoryAddResult(True, added, "Инвентарь заполнен.")
+        return InventoryAddResult(False, reason="Инвентарь заполнен.")
 
     def get_cell(self, column: int, row: int) -> ItemStack | None:
         if column == 0:

--- a/src/sv/items/item.py
+++ b/src/sv/items/item.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import arcade
 
+from sv.core.config import Settings
+
 
 class ItemKind(Enum):
     WEAPON = auto()
@@ -77,6 +79,8 @@ class ItemStack:
 
 _ITEM_TEXTURE_SIZE = 16
 _ITEM_SPRITESHEET_PATH = ":assets:/sprites/items.png"
+MAP_ITEM_SCALE = 2.0
+TILE_SIZE = Settings.TILE_SIZE
 
 
 @lru_cache(maxsize=1)
@@ -88,6 +92,28 @@ def load_item_textures() -> tuple[arcade.Texture, ...]:
         sheet = arcade.load_spritesheet(fallback_path)
     textures = sheet.get_texture_grid((_ITEM_TEXTURE_SIZE, _ITEM_TEXTURE_SIZE), columns=4, count=4)
     return tuple(textures)
+
+
+class MapItem(arcade.Sprite):
+    """Non-blocking item pickup placed on the tile grid."""
+
+    def __init__(
+        self,
+        definition: ItemDefinition,
+        tile_x: int,
+        tile_y: int,
+        *,
+        quantity: int = 1,
+    ) -> None:
+        super().__init__(scale=MAP_ITEM_SCALE)
+        self.definition = definition
+        self.stack = ItemStack(definition, quantity)
+        self.tile_x = int(tile_x)
+        self.tile_y = int(tile_y)
+        self.blocking = False
+        self.texture = load_item_textures()[definition.icon_index]
+        self.center_x = self.tile_x * TILE_SIZE + TILE_SIZE / 2
+        self.center_y = self.tile_y * TILE_SIZE + TILE_SIZE / 2
 
 
 DEFAULT_ITEM_DEFINITIONS: dict[str, ItemDefinition] = {

--- a/src/sv/items/item.py
+++ b/src/sv/items/item.py
@@ -79,6 +79,7 @@ class ItemStack:
 
 _ITEM_TEXTURE_SIZE = 16
 _ITEM_SPRITESHEET_PATH = ":assets:/sprites/items.png"
+_CHEST_TEXTURE_PATH = ":assets:/sprites/chest.png"
 MAP_ITEM_SCALE = 2.0
 TILE_SIZE = Settings.TILE_SIZE
 
@@ -92,6 +93,15 @@ def load_item_textures() -> tuple[arcade.Texture, ...]:
         sheet = arcade.load_spritesheet(fallback_path)
     textures = sheet.get_texture_grid((_ITEM_TEXTURE_SIZE, _ITEM_TEXTURE_SIZE), columns=4, count=4)
     return tuple(textures)
+
+
+@lru_cache(maxsize=1)
+def load_chest_texture() -> arcade.Texture:
+    try:
+        return arcade.load_texture(_CHEST_TEXTURE_PATH)
+    except FileNotFoundError:
+        fallback_path = Path(__file__).resolve().parents[3] / "assets" / "sprites" / "chest.png"
+        return arcade.load_texture(fallback_path)
 
 
 class MapItem(arcade.Sprite):
@@ -112,6 +122,20 @@ class MapItem(arcade.Sprite):
         self.tile_y = int(tile_y)
         self.blocking = False
         self.texture = load_item_textures()[definition.icon_index]
+        self.center_x = self.tile_x * TILE_SIZE + TILE_SIZE / 2
+        self.center_y = self.tile_y * TILE_SIZE + TILE_SIZE / 2
+
+
+class MapChest(arcade.Sprite):
+    """Blocking chest with one loot stack."""
+
+    def __init__(self, stack: ItemStack, tile_x: int, tile_y: int) -> None:
+        super().__init__()
+        self.stack = stack
+        self.tile_x = int(tile_x)
+        self.tile_y = int(tile_y)
+        self.blocking = True
+        self.texture = load_chest_texture()
         self.center_x = self.tile_x * TILE_SIZE + TILE_SIZE / 2
         self.center_y = self.tile_y * TILE_SIZE + TILE_SIZE / 2
 

--- a/src/sv/world/scene_builder.py
+++ b/src/sv/world/scene_builder.py
@@ -10,6 +10,7 @@ import arcade
 from sv.core.config import Settings
 from sv.core.player_resources import PlayerCarryover, apply_player_carryover
 from sv.entities import Player, Skeleton
+from sv.items import DEFAULT_ITEM_DEFINITIONS, MapItem
 from sv.world.level_generator import LevelGenerator
 
 
@@ -58,6 +59,7 @@ def build_level_scene(
     scene = arcade.Scene()
     scene.add_sprite_list("Ground")
     scene.add_sprite_list("Walls")
+    scene.add_sprite_list("Items")
     scene.add_sprite_list("Player")
     scene.add_sprite_list("Skeleton")
 
@@ -77,8 +79,17 @@ def build_level_scene(
         and (x, y) != stairs_xy
     ]
     enemy_count = min(6, 1 + depth // 2)
-    for sx, sy in rng.sample(floor_tiles, k=min(enemy_count, len(floor_tiles))):
+    enemy_tiles = rng.sample(floor_tiles, k=min(enemy_count, len(floor_tiles)))
+    for sx, sy in enemy_tiles:
         scene.add_sprite("Skeleton", Skeleton(tile_x=sx, tile_y=sy))
+
+    occupied_tiles = set(enemy_tiles)
+    item_tiles = [tile for tile in floor_tiles if tile not in occupied_tiles]
+    item_count = min(4, 1 + depth // 2)
+    item_definitions = tuple(DEFAULT_ITEM_DEFINITIONS.values())
+    for index, (sx, sy) in enumerate(rng.sample(item_tiles, k=min(item_count, len(item_tiles)))):
+        definition = item_definitions[index % len(item_definitions)]
+        scene.add_sprite("Items", MapItem(definition, sx, sy))
 
     return SceneBuildResult(
         level=level,

--- a/src/sv/world/scene_builder.py
+++ b/src/sv/world/scene_builder.py
@@ -10,7 +10,7 @@ import arcade
 from sv.core.config import Settings
 from sv.core.player_resources import PlayerCarryover, apply_player_carryover
 from sv.entities import Player, Skeleton
-from sv.items import DEFAULT_ITEM_DEFINITIONS, MapItem
+from sv.items import DEFAULT_ITEM_DEFINITIONS, ItemStack, MapChest, MapItem
 from sv.world.level_generator import LevelGenerator
 
 
@@ -60,6 +60,7 @@ def build_level_scene(
     scene.add_sprite_list("Ground")
     scene.add_sprite_list("Walls")
     scene.add_sprite_list("Items")
+    scene.add_sprite_list("Chests")
     scene.add_sprite_list("Player")
     scene.add_sprite_list("Skeleton")
 
@@ -90,6 +91,12 @@ def build_level_scene(
     for index, (sx, sy) in enumerate(rng.sample(item_tiles, k=min(item_count, len(item_tiles)))):
         definition = item_definitions[index % len(item_definitions)]
         scene.add_sprite("Items", MapItem(definition, sx, sy))
+
+    occupied_tiles.update((sprite.tile_x, sprite.tile_y) for sprite in scene["Items"])
+    chest_tiles = [tile for tile in floor_tiles if tile not in occupied_tiles]
+    if chest_tiles:
+        chest_x, chest_y = rng.sample(chest_tiles, k=1)[0]
+        scene.add_sprite("Chests", MapChest(ItemStack(DEFAULT_ITEM_DEFINITIONS["potion"]), chest_x, chest_y))
 
     return SceneBuildResult(
         level=level,

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -29,6 +29,12 @@ class DummyScene:
         self.sprite_lists = {"Entities": entities}
 
 
+class ArcadeLikeScene:
+    def __init__(self, entities):
+        self.sprite_lists = None
+        self._sprite_lists = [entities]
+
+
 class CollisionTests(unittest.TestCase):
     def setUp(self):
         # 2x2 all-walkable map
@@ -61,6 +67,16 @@ class CollisionTests(unittest.TestCase):
         scene = DummyScene([mover, walling_entity])
 
         res, blocker, _, _ = can_move(mover, 1, 0, self.level, scene)
+        self.assertEqual(res, MoveResult.BLOCKED_ENTITY)
+        self.assertIs(blocker, walling_entity)
+
+    def test_arcade_scene_private_sprite_lists_block_move(self):
+        mover = DummyEntity(0, 0, blocking=True)
+        walling_entity = DummyEntity(1, 0, blocking=True)
+        scene = ArcadeLikeScene([mover, walling_entity])
+
+        res, blocker, _, _ = can_move(mover, 1, 0, self.level, scene)
+
         self.assertEqual(res, MoveResult.BLOCKED_ENTITY)
         self.assertIs(blocker, walling_entity)
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from sv.items import DEFAULT_ITEM_DEFINITIONS, Inventory, ItemStack
+
+
+class InventoryTests(unittest.TestCase):
+    def test_add_stack_places_item_in_empty_storage_cell(self):
+        inventory = Inventory()
+        stack = ItemStack(DEFAULT_ITEM_DEFINITIONS["sword"])
+
+        result = inventory.add_stack(stack)
+
+        self.assertTrue(result.added)
+        self.assertEqual(result.quantity_added, 1)
+        self.assertIs(inventory.storage[0].definition, stack.definition)
+
+    def test_add_stack_merges_stackable_items(self):
+        inventory = Inventory()
+        potion = DEFAULT_ITEM_DEFINITIONS["potion"]
+        inventory.storage[0] = ItemStack(potion, 3)
+
+        result = inventory.add_stack(ItemStack(potion, 2))
+
+        self.assertTrue(result.added)
+        self.assertEqual(result.quantity_added, 2)
+        self.assertEqual(inventory.storage[0].quantity, 5)
+
+    def test_add_stack_reports_full_inventory(self):
+        inventory = Inventory()
+        sword = DEFAULT_ITEM_DEFINITIONS["sword"]
+        inventory.storage = [ItemStack(sword) for _ in inventory.storage]
+
+        result = inventory.add_stack(ItemStack(DEFAULT_ITEM_DEFINITIONS["armor"]))
+
+        self.assertFalse(result.added)
+        self.assertEqual(result.reason, "Инвентарь заполнен.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scene_builder.py
+++ b/tests/test_scene_builder.py
@@ -67,6 +67,7 @@ class SceneBuilderTests(unittest.TestCase):
         self.assertEqual(result.world_height, 64)
         self.assertEqual(len(result.scene["Ground"]), 4)
         self.assertEqual(len(result.scene["Walls"]), 1)
+        self.assertEqual(len(result.scene["Items"]), 1)
         self.assertEqual(len(result.scene["Player"]), 1)
         self.assertEqual(len(result.scene["Skeleton"]), 1)
         self.assertIs(result.player, result.scene["Player"][0])
@@ -81,6 +82,7 @@ class SceneBuilderTests(unittest.TestCase):
         )
 
         self.assertEqual(len(result.scene["Skeleton"]), 6)
+        self.assertEqual(len(result.scene["Items"]), 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_scene_builder.py
+++ b/tests/test_scene_builder.py
@@ -68,6 +68,7 @@ class SceneBuilderTests(unittest.TestCase):
         self.assertEqual(len(result.scene["Ground"]), 4)
         self.assertEqual(len(result.scene["Walls"]), 1)
         self.assertEqual(len(result.scene["Items"]), 1)
+        self.assertEqual(len(result.scene["Chests"]), 0)
         self.assertEqual(len(result.scene["Player"]), 1)
         self.assertEqual(len(result.scene["Skeleton"]), 1)
         self.assertIs(result.player, result.scene["Player"][0])
@@ -83,6 +84,17 @@ class SceneBuilderTests(unittest.TestCase):
 
         self.assertEqual(len(result.scene["Skeleton"]), 6)
         self.assertEqual(len(result.scene["Items"]), 4)
+        self.assertEqual(len(result.scene["Chests"]), 1)
+
+        occupied = {
+            (sprite.tile_x, sprite.tile_y)
+            for list_name in ("Skeleton", "Items")
+            for sprite in result.scene[list_name]
+        }
+        chest = result.scene["Chests"][0]
+        self.assertNotIn((chest.tile_x, chest.tile_y), occupied)
+        self.assertNotEqual((chest.tile_x, chest.tile_y), (0, 0))
+        self.assertNotEqual((chest.tile_x, chest.tile_y), (9, 1))
 
 
 if __name__ == "__main__":

--- a/tests/test_turn_controller.py
+++ b/tests/test_turn_controller.py
@@ -21,10 +21,11 @@ class FakeMessageLog:
 
 
 class FakeScene:
-    def __init__(self, skeletons=None, player=None):
+    def __init__(self, skeletons=None, player=None, items=None):
         self._lists = {
             "Skeleton": skeletons or [],
             "Player": [player] if player is not None else [],
+            "Items": items or [],
         }
 
     def get_sprite_list(self, name):
@@ -39,6 +40,7 @@ class FakePlayer:
         self.max_hp = hp
         self.removed = False
         self.moving = False
+        self.inventory = None
 
 
 class FakeEnemy:
@@ -51,6 +53,37 @@ class FakeEnemy:
 
     def attack(self, target):
         target.hp = max(0, target.hp - self.damage)
+
+
+class FakeAddResult:
+    def __init__(self, added=True, reason=None):
+        self.added = added
+        self.reason = reason
+
+
+class FakeInventory:
+    def __init__(self, *, added=True):
+        self.added = added
+        self.added_stacks = []
+
+    def add_stack(self, stack):
+        self.added_stacks.append(stack)
+        return FakeAddResult(self.added, "Инвентарь заполнен.")
+
+
+class FakeStack:
+    name = "Зелье"
+
+
+class FakeItem:
+    def __init__(self, tile_x=0, tile_y=0):
+        self.tile_x = tile_x
+        self.tile_y = tile_y
+        self.stack = FakeStack()
+        self.removed = False
+
+    def remove_from_sprite_lists(self):
+        self.removed = True
 
 
 class TurnControllerTests(unittest.TestCase):
@@ -117,6 +150,59 @@ class TurnControllerTests(unittest.TestCase):
 
         self.assertTrue(handled)
         self.assertTrue(state.is_player_turn())
+
+    def test_auto_pickup_after_move_adds_stack_without_extra_turn(self):
+        state = StateManager()
+        state.enter_game(GamePhase.PLAYER_ANIM)
+        player = FakePlayer(tile_x=2, tile_y=3)
+        player.inventory = FakeInventory()
+        item = FakeItem(tile_x=2, tile_y=3)
+        log = FakeMessageLog()
+        controller, _, _ = self._controller(state, log)
+        controller.configure([[1]], FakeScene(player=player, items=[item]), player)
+
+        handled = controller.advance_after_player_animation(stairs_xy=None)
+
+        self.assertTrue(handled)
+        self.assertTrue(item.removed)
+        self.assertEqual(player.inventory.added_stacks, [item.stack])
+        self.assertTrue(state.is_player_turn())
+        self.assertEqual(log.messages, [("Вы подобрали Зелье", "loot")])
+
+    def test_manual_pickup_adds_stack_and_spends_turn(self):
+        state = StateManager()
+        state.enter_game(GamePhase.PLAYER_TURN)
+        player = FakePlayer(tile_x=2, tile_y=3)
+        player.inventory = FakeInventory()
+        item = FakeItem(tile_x=2, tile_y=3)
+        log = FakeMessageLog()
+        controller, _, _ = self._controller(state, log)
+        controller.configure([[1]], FakeScene(player=player, items=[item]), player)
+
+        picked_up = controller.pick_up_at_player()
+
+        self.assertTrue(picked_up)
+        self.assertTrue(item.removed)
+        self.assertEqual(player.inventory.added_stacks, [item.stack])
+        self.assertTrue(state.is_player_turn())
+        self.assertEqual(log.messages, [("Вы подобрали Зелье", "loot")])
+
+    def test_manual_pickup_failure_does_not_spend_turn(self):
+        state = StateManager()
+        state.enter_game(GamePhase.PLAYER_TURN)
+        player = FakePlayer(tile_x=2, tile_y=3)
+        player.inventory = FakeInventory(added=False)
+        item = FakeItem(tile_x=2, tile_y=3)
+        log = FakeMessageLog()
+        controller, _, _ = self._controller(state, log)
+        controller.configure([[1]], FakeScene(player=player, items=[item]), player)
+
+        picked_up = controller.pick_up_at_player()
+
+        self.assertFalse(picked_up)
+        self.assertFalse(item.removed)
+        self.assertTrue(state.is_player_turn())
+        self.assertEqual(log.messages, [("Инвентарь заполнен.", "info")])
 
     def test_player_on_stairs_triggers_depth_advance(self):
         state = StateManager()

--- a/tests/test_turn_controller.py
+++ b/tests/test_turn_controller.py
@@ -10,6 +10,8 @@ if str(SRC) not in sys.path:
 
 from sv.core.state_manager import GamePhase, StateManager
 from sv.core.turn_controller import TurnController
+from sv.core.collision import MoveResult
+from sv.items import DEFAULT_ITEM_DEFINITIONS
 
 
 class FakeMessageLog:
@@ -21,15 +23,19 @@ class FakeMessageLog:
 
 
 class FakeScene:
-    def __init__(self, skeletons=None, player=None, items=None):
+    def __init__(self, skeletons=None, player=None, items=None, chests=None):
         self._lists = {
             "Skeleton": skeletons or [],
             "Player": [player] if player is not None else [],
             "Items": items or [],
+            "Chests": chests or [],
         }
 
     def get_sprite_list(self, name):
         return self._lists.get(name, [])
+
+    def add_sprite(self, name, sprite):
+        self._lists.setdefault(name, []).append(sprite)
 
 
 class FakePlayer:
@@ -38,9 +44,15 @@ class FakePlayer:
         self.tile_y = tile_y
         self.hp = hp
         self.max_hp = hp
+        self.light = 3
         self.removed = False
         self.moving = False
         self.inventory = None
+
+    def spend_light(self, amount=1):
+        spent = min(self.light, amount)
+        self.light -= spent
+        return spent
 
 
 class FakeEnemy:
@@ -53,6 +65,15 @@ class FakeEnemy:
 
     def attack(self, target):
         target.hp = max(0, target.hp - self.damage)
+
+
+class FakeMovingPlayer(FakePlayer):
+    def __init__(self, blocker, **kwargs):
+        super().__init__(**kwargs)
+        self.blocker = blocker
+
+    def attempt_move(self, dx, dy, level, scene):
+        return MoveResult.BLOCKED_ENTITY, self.blocker
 
 
 class FakeAddResult:
@@ -72,7 +93,9 @@ class FakeInventory:
 
 
 class FakeStack:
-    name = "Зелье"
+    definition = DEFAULT_ITEM_DEFINITIONS["potion"]
+    name = definition.name
+    quantity = 1
 
 
 class FakeItem:
@@ -81,9 +104,16 @@ class FakeItem:
         self.tile_y = tile_y
         self.stack = FakeStack()
         self.removed = False
+        self.blocking = False
 
     def remove_from_sprite_lists(self):
         self.removed = True
+
+
+class FakeChest(FakeItem):
+    def __init__(self, tile_x=0, tile_y=0):
+        super().__init__(tile_x, tile_y)
+        self.blocking = True
 
 
 class TurnControllerTests(unittest.TestCase):
@@ -203,6 +233,69 @@ class TurnControllerTests(unittest.TestCase):
         self.assertFalse(item.removed)
         self.assertTrue(state.is_player_turn())
         self.assertEqual(log.messages, [("Инвентарь заполнен.", "info")])
+
+    def test_manual_pickup_does_not_open_adjacent_chest(self):
+        state = StateManager()
+        state.enter_game(GamePhase.PLAYER_TURN)
+        player = FakePlayer(tile_x=2, tile_y=3)
+        player.inventory = FakeInventory()
+        chest = FakeChest(tile_x=3, tile_y=3)
+        log = FakeMessageLog()
+        controller, _, _ = self._controller(state, log)
+        controller.configure([[1]], FakeScene(player=player, chests=[chest]), player)
+
+        opened = controller.pick_up_at_player()
+
+        self.assertFalse(opened)
+        self.assertFalse(chest.removed)
+        self.assertEqual(player.inventory.added_stacks, [])
+        self.assertTrue(state.is_player_turn())
+        self.assertEqual(log.messages, [("Здесь ничего нет", "info")])
+
+    def test_bumping_chest_opens_and_drops_loot(self):
+        state = StateManager()
+        state.enter_game(GamePhase.PLAYER_TURN)
+        chest = FakeChest(tile_x=3, tile_y=3)
+        player = FakeMovingPlayer(chest, tile_x=2, tile_y=3)
+        player.inventory = FakeInventory()
+        log = FakeMessageLog()
+        controller, _, _ = self._controller(state, log)
+        controller.configure([[1]], FakeScene(player=player, chests=[chest]), player)
+
+        result, blocker = controller.try_player_move(1, 0)
+
+        self.assertEqual(result, MoveResult.BLOCKED_ENTITY)
+        self.assertIs(blocker, chest)
+        self.assertTrue(chest.removed)
+        self.assertEqual(player.inventory.added_stacks, [])
+        self.assertEqual(len(controller.scene.get_sprite_list("Items")), 1)
+        dropped_item = controller.scene.get_sprite_list("Items")[0]
+        self.assertEqual((dropped_item.tile_x, dropped_item.tile_y), (3, 3))
+        self.assertIs(dropped_item.stack.definition, chest.stack.definition)
+        self.assertEqual(player.light, 2)
+        self.assertTrue(state.is_player_turn())
+        self.assertEqual(log.messages, [])
+
+    def test_chest_opening_does_not_require_inventory_space(self):
+        state = StateManager()
+        state.enter_game(GamePhase.PLAYER_TURN)
+        chest = FakeChest(tile_x=2, tile_y=3)
+        player = FakeMovingPlayer(chest, tile_x=1, tile_y=3)
+        player.inventory = FakeInventory(added=False)
+        log = FakeMessageLog()
+        controller, _, _ = self._controller(state, log)
+        controller.configure([[1]], FakeScene(player=player, chests=[chest]), player)
+
+        result, blocker = controller.try_player_move(1, 0)
+
+        self.assertEqual(result, MoveResult.BLOCKED_ENTITY)
+        self.assertIs(blocker, chest)
+        self.assertTrue(chest.removed)
+        self.assertEqual(player.inventory.added_stacks, [])
+        self.assertEqual(len(controller.scene.get_sprite_list("Items")), 1)
+        self.assertEqual(player.light, 2)
+        self.assertTrue(state.is_player_turn())
+        self.assertEqual(log.messages, [])
 
     def test_player_on_stairs_triggers_depth_advance(self):
         state = StateManager()


### PR DESCRIPTION
## Что сделано

Добавлены предметы на карте и базовые сундуки с лутом для MVP-геймплея.

## Основные изменения

- Предметы теперь спавнятся на уровне отдельным sprite list и подбираются автоматически при наступании.
- Клавиша `C` выполняет ручной подбор предмета под игроком.
- Инвентарь умеет добавлять найденные предметы и стакает одинаковые расходники.
- Сундуки спавнятся как блокирующие объекты: при движении в сундук он открывается, исчезает и оставляет предмет на своём тайле.
- Коллизии теперь учитывают blocking-объекты из Arcade scene, включая сундуки.