### PR TITLE
Allow Nuitka support downloads in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          prerelease_args=()
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then
+            prerelease_args+=(--prerelease)
+          fi
+
           gh release create "$GITHUB_REF_NAME" release-assets/* \
             --verify-tag \
-            --generate-notes
+            --generate-notes \
+            "${prerelease_args[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     needs: validate-tag
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/scripts/build_nuitka_windows.ps1
+++ b/scripts/build_nuitka_windows.ps1
@@ -40,4 +40,5 @@ $env:NUITKA_CACHE_DIR = if ($env:NUITKA_CACHE_DIR) {
     --output-folder-name=Shardveil `
     --windows-console-mode=disable `
     --force-stderr-spec="{PROGRAM_BASE}.err.txt" `
+    --assume-yes-for-downloads `
     --windows-icon-from-ico=packaging/icons/shardveil.ico


### PR DESCRIPTION
## Что сделано

Исправлен первый запуск автоматической release-сборки после `v0.6.0-alpha`.

## Основные изменения

- Windows Nuitka-сборка автоматически разрешает загрузку Dependency Walker через `--assume-yes-for-downloads`.
- Release matrix больше не отменяет независимую platform-сборку после ошибки другого runner благодаря `fail-fast: false`.